### PR TITLE
Add support for webpack 4

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -33,12 +33,12 @@ module.exports = function (content) {
 
     var context = this
     var query = utils.getOptions(this) || {}
-    var options = Object.assign({}, this.options.ng, this.ng, query)
+    var options = Object.assign({}, this.query.ng, this.ng, this.query)
     var filePath = this.resourcePath
     var fileName = path.basename(filePath)
     var moduleId = 'data-ng-' + hash(filePath)
 
-    if (this.options.babel) {
+    if (this.query.babel) {
         defaultLoaders.js = 'babel-loader'
     }
 

--- a/lib/style-rewrite.js
+++ b/lib/style-rewrite.js
@@ -51,7 +51,7 @@ module.exports = function (css, map) {
   var cb = this.async()
 
   var query = loaderUtils.getOptions(this) || {}
-  var options = this.options.ng || {}
+  var options = this.query.ng || {}
   var autoprefixOptions = options.autoprefixer
   var postcssOptions = options.postcss
 
@@ -72,7 +72,7 @@ module.exports = function (css, map) {
   if (autoprefixOptions !== false) {
     autoprefixOptions = assign(
       {},
-      this.options.autoprefixer,
+      this.query.autoprefixer,
       autoprefixOptions
     )
     var autoprefixer = require('autoprefixer')(autoprefixOptions)

--- a/lib/template-loader.js
+++ b/lib/template-loader.js
@@ -7,7 +7,7 @@ module.exports = function(content)
     this.cacheable()
     var callback = this.async()
     var options = utils.getOptions(this)
-    var ngOptions = this.options.ng 
+    var ngOptions = this.query.ng
 
     if(ngOptions && ngOptions.template){
         for(var key in ngOptions.template){


### PR DESCRIPTION
This adds basic support for webpack 4. "Basic", because I haven't tested all features/combinations possible. And I didn't execute the tests (don't know how).

Webpack 4 removed support for `this.options`. This is now `this.query`. This is all that I changed, and it seems to work with that.