### PR TITLE
Add option hotReload

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -15,6 +15,10 @@ module.exports = function (content) {
 
     this.cacheable()
 
+    var defaultOptions = {
+        hotReload: true
+    }
+
     var defaultLoaders = {
         html: 'html-loader',
         css: 'style-loader!css-loader',
@@ -33,7 +37,7 @@ module.exports = function (content) {
 
     var context = this
     var query = utils.getOptions(this) || {}
-    var options = Object.assign({}, this.query.ng, this.ng, this.query)
+    var options = Object.assign({}, defaultOptions, this.query.ng, this.ng, this.query)
     var filePath = this.resourcePath
     var fileName = path.basename(filePath)
     var moduleId = 'data-ng-' + hash(filePath)
@@ -225,7 +229,7 @@ module.exports = function (content) {
 
     var hotId = JSON.stringify(`${moduleId}/${fileName}`)
     var srcFile = JSON.stringify(path.relative(process.cwd(), filePath))
-    
+
     output += `
         __comp_script__ = __comp_script__ || {};
         if(__comp_script__.__esModule) __comp_script__ = __comp_script__.default;
@@ -240,31 +244,33 @@ module.exports = function (content) {
 
 
     // ng api with hot reload
-    output += `
-        const angular = require('angular');
-        const api = require('ng-hot-reload-api');
+    if(options.hotReload) {
+        output += `
+            const angular = require('angular');
+            const api = require('ng-hot-reload-api');
 
-        api.install(angular, ${options.replace});
-        
-        if(module.hot) {
+            api.install(angular, ${options.replace});
 
-            if (!api.compatible) {
-                throw new Error('ng-hot-reload-api is not compatible with the version of AngularJs you are using.')
+            if(module.hot) {
+
+                if (!api.compatible) {
+                    throw new Error('ng-hot-reload-api is not compatible with the version of AngularJs you are using.')
+                }
+
+                module.hot.accept(function(e){
+                    console.error('[NGC] Error in compilation file. ', e);
+                });
+
+                if(!module.hot.data){
+                    // register
+                    api.register(${hotId}, __comp_script__);
+                } else {
+                    // update
+                    api.reload(${hotId}, __comp_script__);
+                }
             }
-
-            module.hot.accept(function(e){
-                console.error('[NGC] Error in compilation file. ', e);
-            });
-
-            if(!module.hot.data){
-                // register
-                api.register(${hotId}, __comp_script__);
-            } else {
-                // update
-                api.reload(${hotId}, __comp_script__);
-            }
-        }
-    `
+        `
+    }
 
     return output;
 }


### PR DESCRIPTION
This adds a new option `hotReload` which defaults to `true` to keep compatibility.

Disabling this will save few bytes per component and does not include `ng-hot-reload-api` on the output bundle.